### PR TITLE
Update client.connect() use

### DIFF
--- a/examples/LegacyEthernetTest/LegacyEthernetTest.ino
+++ b/examples/LegacyEthernetTest/LegacyEthernetTest.ino
@@ -168,7 +168,7 @@ void testEthernet(bool dhcp) {
   Serial.print("Attempt to connect to port 80 on ");
   Serial.println(Ethernet.gatewayIP());
   EthernetClient client;
-  if (client.connect(Ethernet.gatewayIP(), 80)) {
+  if (client.connect(Ethernet.gatewayIP(), 80) == 1) {
     Serial.println("\t...success");
   } else {
     Serial.println("\t...ERROR");

--- a/examples/LegacyEthernetTest/LegacyEthernetTest.ino
+++ b/examples/LegacyEthernetTest/LegacyEthernetTest.ino
@@ -165,15 +165,18 @@ void testEthernet(bool dhcp) {
   printEthernetStatus();
   Serial.println();
 
-  Serial.print("Attempt to connect to port 80 on ");
+  Serial.print("Attempt to connect to port 80 or 443 on ");
   Serial.println(Ethernet.gatewayIP());
   EthernetClient client;
   if (client.connect(Ethernet.gatewayIP(), 80) == 1) {
-    Serial.println("\t...success");
+    Serial.println("\t...success (port 80)");
+    client.stop();
+  } else if (client.connect(Ethernet.gatewayIP(), 443) == 1) {
+    Serial.println("\t...success (port 443)");
+    client.stop();
   } else {
     Serial.println("\t...ERROR");
   }
-  client.stop();
   Serial.println();
 }
 


### PR DESCRIPTION
Summary of the two changes:
1. Fix checking `client.connect()` for an error; only '1' is success. Implicit Boolean conversion will turn non-zero errors into `true`.
2. Add attempt to connect to port 443 on the gateway because some gateways might not have port 80 open.